### PR TITLE
Implementing custom stats section

### DIFF
--- a/lib/pages/StatisticsPage.dart
+++ b/lib/pages/StatisticsPage.dart
@@ -117,14 +117,14 @@ class _StatisticsPageState extends State<StatisticsPage> {
                 onPressed: () async {
                   final DateTime? picked = await showDatePicker(
                     context: context,
-                    initialDate: start,
+                    // initialDate: start,
                     firstDate: DateTime(2023),
                     lastDate: DateTime.now().add(const Duration(days: 1095)),
                   );
                   if (picked != null) {
                     setState(() {
                       _dateStart.text = DateFormat('dd/MM/yyyy').format(picked);
-                      start = picked;
+                      // start = picked;
                     });
                   }
                 },
@@ -157,14 +157,14 @@ class _StatisticsPageState extends State<StatisticsPage> {
                 onPressed: () async {
                   final DateTime? picked = await showDatePicker(
                     context: context,
-                    initialDate: end,
+                    // initialDate: end,
                     firstDate: DateTime(2023),
                     lastDate: DateTime.now().add(const Duration(days: 1095)),
                   );
                   if (picked != null) {
                     setState(() {
                       _dateEnd.text = DateFormat('dd/MM/yyyy').format(picked);
-                      end = picked;
+                      // end = picked;
                     });
                   }
                 },
@@ -176,11 +176,45 @@ class _StatisticsPageState extends State<StatisticsPage> {
         const Gap(25),
         ElevatedButton(
             style: ElevatedButton.styleFrom(backgroundColor: Colors.redAccent),
-            onPressed: () {},
+            onPressed: (_dateStart.text.isEmpty || _dateEnd.text.isEmpty)
+                ? null
+                : () {
+                    DateTime t1 = parseDate(_dateStart.text);
+                    DateTime t2 = parseDate(_dateEnd.text);
+                    Duration difference_dur = t2.difference(t1);
+                    int diff = difference_dur.inDays;
+                    if (diff <= 0) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Invalid Date Range!'),
+                          backgroundColor: Colors.red,
+                        ),
+                      );
+                      return;
+                    } else if (diff < 5) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Day range must be greater than 4'),
+                          backgroundColor: Colors.red,
+                        ),
+                      );
+                      return;
+                    } else if (diff > 20) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Day range cannot be greater than 20'),
+                          backgroundColor: Colors.red,
+                        ),
+                      );
+                      return;
+                    }
+                    start = t1;
+                    end = t2;
+                  },
             child: const Padding(
               padding: EdgeInsets.all(8),
               child: Text(
-                "Refresh Graph",
+                "Build/Refresh Graph",
                 style: TextStyle(color: Colors.white),
               ),
             ))
@@ -275,5 +309,12 @@ class _StatisticsPageState extends State<StatisticsPage> {
         ),
       ],
     );
+  }
+
+  //parses a date in the format dd-mm-yyyy
+  DateTime parseDate(String input) {
+    List<String> tokens = input.split("/"); //[dd,mm,yyyy]
+    String toParse = "${tokens[2]}-${tokens[1]}-${tokens[0]}";
+    return DateTime.parse(toParse);
   }
 }

--- a/lib/pages/StatisticsPage.dart
+++ b/lib/pages/StatisticsPage.dart
@@ -16,49 +16,175 @@ class StatisticsPage extends StatefulWidget {
 }
 
 class _StatisticsPageState extends State<StatisticsPage> {
+  final List<bool> _modes = [
+    true,
+    false
+  ]; //first bool means standard view, second means custom view
+  TextEditingController _dateStart = TextEditingController();
+  TextEditingController _dateEnd = TextEditingController();
+  DateTime? start;
+  DateTime? end;
   @override
   Widget build(BuildContext context) {
-    List<DateTime> days = DailyInfoList.weekRange(globalReferenceDay);
-    List<DailyInfoList> plinfos = days.map(
-      (now) {
-        return DailyInfoList.fromDate(now);
-      },
-    ).toList();
-    List<double> hours = plinfos.map((plinfo) {
-      if (initialGameValue == defaultGameSelection) {
-        return plinfo.totalHours();
-      } else {
-        return plinfo.hoursFor(initialGameValue);
-      }
-    }).toList();
-    return SafeArea(
-      child: Scaffold(
+    if (_modes[0]) {
+      List<DateTime> days = DailyInfoList.weekRange(globalReferenceDay);
+      List<DailyInfoList> plinfos = days.map(
+        (now) {
+          return DailyInfoList.fromDate(now);
+        },
+      ).toList();
+      List<double> hours = plinfos.map((plinfo) {
+        if (initialGameValue == defaultGameSelection) {
+          return plinfo.totalHours();
+        } else {
+          return plinfo.hoursFor(initialGameValue);
+        }
+      }).toList();
+      return SafeArea(
+        child: Scaffold(
+          body: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                toggleViews(),
+                const Gap(25),
+                Text(
+                  "Selected day: ${convertDate(globalReferenceDay)}",
+                  style: const TextStyle(color: Colors.white, fontSize: 20),
+                ),
+                const Gap(15),
+                selectGameDropdown(),
+                const Gap(18),
+                Text(
+                  "${formatNumericDate(DailyInfoList.getMostRecentMonday(globalReferenceDay))} - ${formatNumericDate(DailyInfoList.getNearestSunday(globalReferenceDay))}",
+                  style: const TextStyle(color: Colors.white, fontSize: 20),
+                ),
+                const Gap(12),
+                SizedBox(
+                  height: MediaQuery.of(context).size.height * 0.55,
+                  width: MediaQuery.of(context).size.width * 0.93,
+                  child: LineChartWidget(
+                      game_name: initialGameValue, hours: hours),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    } else {
+      return SafeArea(
+          child: Scaffold(
         body: Center(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
-                "Selected day: ${convertDate(globalReferenceDay)}",
-                style: const TextStyle(color: Colors.white, fontSize: 20),
-              ),
-              const Gap(15),
-              selectGameDropdown(),
-              const Gap(18),
-              Text(
-                "${formatNumericDate(DailyInfoList.getMostRecentMonday(globalReferenceDay))} - ${formatNumericDate(DailyInfoList.getNearestSunday(globalReferenceDay))}",
-                style: const TextStyle(color: Colors.white, fontSize: 20),
-              ),
-              const Gap(12),
-              SizedBox(
-                height: MediaQuery.of(context).size.height * 0.55,
-                width: MediaQuery.of(context).size.width * 0.93,
-                child:
-                    LineChartWidget(game_name: initialGameValue, hours: hours),
-              ),
+              toggleViews(),
+              const Gap(25),
+              datePickers(context),
             ],
           ),
         ),
-      ),
+      ));
+    }
+  }
+
+  Widget datePickers(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          textBaseline: TextBaseline.ideographic,
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              "Enter start date",
+              style: TextStyle(color: Colors.white),
+            ),
+            const Gap(8),
+            SizedBox(
+              width: MediaQuery.of(context).size.width * 0.31,
+              child: TextField(
+                textAlign: TextAlign.center,
+                controller: _dateStart,
+                readOnly: true,
+                style: const TextStyle(color: Colors.redAccent),
+              ),
+            ),
+            const Gap(1),
+            IconButton(
+                // color: Colors.redAccent,
+                onPressed: () async {
+                  final DateTime? picked = await showDatePicker(
+                    context: context,
+                    initialDate: start,
+                    firstDate: DateTime(2023),
+                    lastDate: DateTime.now().add(const Duration(days: 1095)),
+                  );
+                  if (picked != null) {
+                    setState(() {
+                      _dateStart.text = DateFormat('dd/MM/yyyy').format(picked);
+                      start = picked;
+                    });
+                  }
+                },
+                icon: const Icon(Icons.calendar_month)),
+          ],
+        ),
+        const Gap(10),
+        Row(
+          textBaseline: TextBaseline.ideographic,
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              "Enter end date  ",
+              style: TextStyle(color: Colors.white),
+            ),
+            const Gap(8),
+            SizedBox(
+              width: MediaQuery.of(context).size.width * 0.31,
+              child: TextField(
+                textAlign: TextAlign.center,
+                controller: _dateEnd,
+                readOnly: true,
+                style: const TextStyle(color: Colors.redAccent),
+              ),
+            ),
+            const Gap(1),
+            IconButton(
+                // color: Colors.redAccent,
+                onPressed: () async {
+                  final DateTime? picked = await showDatePicker(
+                    context: context,
+                    initialDate: end,
+                    firstDate: DateTime(2023),
+                    lastDate: DateTime.now().add(const Duration(days: 1095)),
+                  );
+                  if (picked != null) {
+                    setState(() {
+                      _dateEnd.text = DateFormat('dd/MM/yyyy').format(picked);
+                      end = picked;
+                    });
+                  }
+                },
+                icon: const Icon(Icons.calendar_month)),
+          ],
+        ),
+        const Gap(23),
+        selectGameDropdown(),
+        const Gap(25),
+        ElevatedButton(
+            style: ElevatedButton.styleFrom(backgroundColor: Colors.redAccent),
+            onPressed: () {},
+            child: const Padding(
+              padding: EdgeInsets.all(8),
+              child: Text(
+                "Refresh Graph",
+                style: TextStyle(color: Colors.white),
+              ),
+            ))
+      ],
     );
   }
 
@@ -112,10 +238,41 @@ class _StatisticsPageState extends State<StatisticsPage> {
               if (value == null) {
                 return;
               }
+
               setState(() {
                 initialGameValue = value as String;
               });
             })
+      ],
+    );
+  }
+
+  ToggleButtons toggleViews() {
+    return ToggleButtons(
+      fillColor: Colors.redAccent,
+      borderRadius: BorderRadius.circular(12),
+      borderWidth: 3,
+      borderColor: Colors.redAccent,
+      selectedBorderColor: Colors.redAccent,
+      isSelected: _modes,
+      onPressed: (index) {
+        setState(() {
+          _modes[0] = !_modes[0];
+          _modes[1] = !_modes[1];
+        });
+      },
+      children: const <Widget>[
+        Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Text(
+            "Standard View",
+            style: TextStyle(color: Colors.white),
+          ),
+        ),
+        Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Text("Custom View", style: TextStyle(color: Colors.white)),
+        ),
       ],
     );
   }

--- a/lib/pages/StatisticsPage.dart
+++ b/lib/pages/StatisticsPage.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:gaming_tracker/main.dart';
 import 'package:gaming_tracker/models/DailyInfoList.dart';
 import 'package:gaming_tracker/pages/CalendarPage.dart';
+import 'package:gaming_tracker/widgets/CustomLineChart.dart';
+import 'package:gaming_tracker/widgets/CustomLinesTileData.dart';
 import 'package:gaming_tracker/widgets/LineChartWidget.dart';
 import 'package:gap/gap.dart';
 import 'package:intl/intl.dart';
@@ -72,6 +74,24 @@ class _StatisticsPageState extends State<StatisticsPage> {
         ),
       );
     } else {
+      //CUSTOM SECTION
+      List<double> hours = [];
+      if (start != null && end != null) {
+        List<DateTime> days = DailyInfoList.getDaysBetween(start!, end!);
+        List<DailyInfoList> plinfos = days.map(
+          (now) {
+            return DailyInfoList.fromDate(now);
+          },
+        ).toList();
+        hours = plinfos.map((plinfo) {
+          if (initialGameValue == defaultGameSelection) {
+            return plinfo.totalHours();
+          } else {
+            return plinfo.hoursFor(initialGameValue);
+          }
+        }).toList();
+      }
+
       return SafeArea(
           child: Scaffold(
         body: Center(
@@ -81,6 +101,16 @@ class _StatisticsPageState extends State<StatisticsPage> {
               toggleViews(),
               const Gap(25),
               datePickers(context),
+              const Gap(20),
+              (start != null && end != null)
+                  ? SizedBox(
+                      height: MediaQuery.of(context).size.height * 0.40,
+                      width: MediaQuery.of(context).size.width * 0.93,
+                      child: CustomLineChart(hours: hours),
+                    )
+                  : SizedBox(
+                      height: MediaQuery.of(context).size.height * 0.40,
+                    ),
             ],
           ),
         ),
@@ -210,11 +240,14 @@ class _StatisticsPageState extends State<StatisticsPage> {
                     }
                     start = t1;
                     end = t2;
+                    setState(() {
+                      CustomLineTiles.startDay = start!;
+                    });
                   },
             child: const Padding(
               padding: EdgeInsets.all(8),
               child: Text(
-                "Build/Refresh Graph",
+                "Confirm Dates",
                 style: TextStyle(color: Colors.white),
               ),
             ))

--- a/lib/pages/StatisticsPage.dart
+++ b/lib/pages/StatisticsPage.dart
@@ -247,7 +247,7 @@ class _StatisticsPageState extends State<StatisticsPage> {
             child: const Padding(
               padding: EdgeInsets.all(8),
               child: Text(
-                "Confirm Dates",
+                "Build/Refresh graph",
                 style: TextStyle(color: Colors.white),
               ),
             ))

--- a/lib/widgets/CustomLineChart.dart
+++ b/lib/widgets/CustomLineChart.dart
@@ -1,0 +1,62 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:gaming_tracker/widgets/CustomLinesTileData.dart';
+
+final List<Color> gradientColorsCustom = [
+  const Color(0xff23b6e6),
+  const Color(0xff02d39a),
+];
+
+class CustomLineChart extends StatefulWidget {
+  List<double> hours;
+  CustomLineChart({super.key, required this.hours});
+  @override
+  State<CustomLineChart> createState() => _CustomLineChartState();
+}
+
+class _CustomLineChartState extends State<CustomLineChart> {
+  @override
+  Widget build(BuildContext context) {
+    return LineChart(
+      LineChartData(
+          titlesData: CustomLineTiles.getTitleData(),
+          minY: 0,
+          minX: 0,
+          maxX: widget.hours.length.toDouble(),
+          maxY: 24,
+          gridData: FlGridData(
+            show: true,
+            getDrawingHorizontalLine: (value) {
+              return const FlLine(
+                color: const Color(0xff37434d),
+                strokeWidth: 1.0,
+              );
+            },
+            drawVerticalLine: true,
+            getDrawingVerticalLine: (value) {
+              return const FlLine(
+                color: const Color(0xff37434d),
+                strokeWidth: 1.0,
+              );
+            },
+          ),
+          borderData: FlBorderData(
+              show: true,
+              border: Border.all(
+                color: const Color(0xFFF23453),
+                width: 1,
+              )),
+          lineBarsData: [
+            LineChartBarData(
+              spots: List.generate(widget.hours.length,
+                  (index) => FlSpot((index).toDouble(), widget.hours[index])),
+              color: gradientColorsCustom[1],
+              belowBarData: BarAreaData(
+                show: true,
+                color: gradientColorsCustom[1].withOpacity(0.3),
+              ),
+            ),
+          ]),
+    );
+  }
+}

--- a/lib/widgets/CustomLineChart.dart
+++ b/lib/widgets/CustomLineChart.dart
@@ -17,6 +17,7 @@ class CustomLineChart extends StatefulWidget {
 class _CustomLineChartState extends State<CustomLineChart> {
   @override
   Widget build(BuildContext context) {
+    CustomLineTiles.previousCustomLabel = "";
     return LineChart(
       LineChartData(
           titlesData: CustomLineTiles.getTitleData(),

--- a/lib/widgets/CustomLinesTileData.dart
+++ b/lib/widgets/CustomLinesTileData.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 class CustomLineTiles {
   static late DateTime startDay;
+  static String previousCustomLabel = "";
   // static late DateTime endDay;
   static FlTitlesData getTitleData() => FlTitlesData(
         bottomTitles: AxisTitles(
@@ -16,7 +17,21 @@ class CustomLineTiles {
               DateTime result = startDay.add(Duration(days: daysAdd));
               day = result.day.toString();
 
-              Widget text = Text(day);
+              if (day == previousCustomLabel) {
+                return const SizedBox.shrink(); // Don't show title
+              } else {
+                previousCustomLabel =
+                    day; //Update previous label with currently displayed label
+              }
+
+              Widget text = Text(
+                day,
+                style: const TextStyle(
+                  color: Color(0xff67727d),
+                  fontWeight: FontWeight.bold,
+                  fontSize: 15,
+                ),
+              );
 
               return SideTitleWidget(
                 axisSide: meta.axisSide,

--- a/lib/widgets/CustomLinesTileData.dart
+++ b/lib/widgets/CustomLinesTileData.dart
@@ -1,0 +1,59 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class CustomLineTiles {
+  static late DateTime startDay;
+  // static late DateTime endDay;
+  static FlTitlesData getTitleData() => FlTitlesData(
+        bottomTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+            reservedSize: 35,
+            getTitlesWidget: (value, meta) {
+              int daysAdd = value.toInt();
+              String day = "";
+
+              DateTime result = startDay.add(Duration(days: daysAdd));
+              day = result.day.toString();
+
+              Widget text = Text(day);
+
+              return SideTitleWidget(
+                axisSide: meta.axisSide,
+                space: 8,
+                child: text,
+              );
+            },
+          ),
+        ),
+        leftTitles: AxisTitles(
+          sideTitles: SideTitles(
+            showTitles: true,
+
+            reservedSize: 40, // Increased to provide space for labels
+            interval: 3,
+            getTitlesWidget: (value, meta) {
+              Widget text;
+
+              // Show titles at intervals of 6
+              text = Text(
+                '${value.toInt()}',
+                style: const TextStyle(
+                  color: Color(0xff67727d),
+                  fontWeight: FontWeight.bold,
+                  fontSize: 15,
+                ),
+              );
+
+              return SideTitleWidget(
+                axisSide: meta.axisSide,
+                space: 12,
+                child: text,
+              );
+            },
+          ),
+        ),
+        topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        rightTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+      );
+}

--- a/lib/widgets/LineTitlesData.dart
+++ b/lib/widgets/LineTitlesData.dart
@@ -2,6 +2,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 class LineTitles {
+  static int previousLabelValue = -1;
   static FlTitlesData getTitleData() => FlTitlesData(
         bottomTitles: AxisTitles(
           sideTitles: SideTitles(
@@ -9,6 +10,12 @@ class LineTitles {
             reservedSize: 35,
             getTitlesWidget: (value, meta) {
               Widget text;
+              int val = value.toInt();
+              if (previousLabelValue == val) {
+                return const SizedBox.shrink(); // Don't show title
+              } else {
+                previousLabelValue = val;
+              }
               switch (value.toInt()) {
                 case 0:
                   text = const Text(


### PR DESCRIPTION
### Description:

- Add a custom stats section to the 'Statistics Page'
- This section allows users to view their gaming data from between a 5-20 day range, and allows 
  them to select the start and end dates. This provides an advantage over the standard view, which 
  provides information for only 1 week at a time and has a more obscure way of selecting the desired 
  week.
- The standard view is the default view, and is the view which is displayed when navigating to the 
  stats page. Both the standard and custom view maintain their state when the stats tab is selected on 
  the landing page. However, if the user navigates to the calendar page or games page, the standard 
  view maintains it's state while the custom view gets reset.

### Screenshots:



<img src="https://github.com/user-attachments/assets/aae2fc06-ac66-4ebe-a101-dfa5d701b3bd" width="200" height="470" alt="Custom-view-1">

<br> 

<img src="https://github.com/user-attachments/assets/efb161ef-fd57-4196-809a-530bc5193caa" width="200" height="470" alt="Custom-view-graph-1">






